### PR TITLE
Add ESS adapter

### DIFF
--- a/src/controller/ControlDeck.cpp
+++ b/src/controller/ControlDeck.cpp
@@ -185,6 +185,11 @@ void ControlDeck::LoadSettings() {
                     profile->RumbleStrength = config->GetFloat(NESTED("Rumble.Strength", ""));
                     profile->UseGyro = config->GetBool(NESTED("Gyro.Enabled", ""));
                     profile->NotchProximityThreshold = config->GetInt(NESTED("Notches.ProximityThreshold", ""));
+                    profile->UseEssAdapter = config->GetBool(NESTED("Ess.Enabled", ""));
+                    profile->InputEssMin = config->GetInt(NESTED("Analog.Threshold", ""));
+                    profile->InputEssMax = config->GetInt(NESTED("Analog.Max", ""));
+                    profile->EssMin = config->GetInt(NESTED("Ess.Min", ""));
+                    profile->EssMax = config->GetInt(NESTED("Ess.Max", ""));
 
                     for (auto const& val : rawProfile["AxisDeadzones"].items()) {
                         profile->AxisDeadzones[std::stoi(val.key())] = val.value();
@@ -210,6 +215,11 @@ void ControlDeck::LoadSettings() {
                     profile->UseGyro = config->GetBool(NESTED("Gyro.Enabled", ""));
                     profile->NotchProximityThreshold = config->GetInt(NESTED("Notches.ProximityThreshold", ""));
                     profile->UseStickDeadzoneForButtons = config->GetBool(NESTED("UseStickDeadzoneForButtons", ""));
+                    profile->UseEssAdapter = config->GetBool(NESTED("Ess.Enabled", ""));
+                    profile->InputEssMin = config->GetInt(NESTED("Analog.Threshold", ""));
+                    profile->InputEssMax = config->GetInt(NESTED("Analog.Max", ""));
+                    profile->EssMin = config->GetInt(NESTED("Ess.Min", ""));
+                    profile->EssMax = config->GetInt(NESTED("Ess.Max", ""));
 
                     for (auto const& val : rawProfile["AxisDeadzones"].items()) {
                         profile->AxisDeadzones[std::stoi(val.key())] = val.value();
@@ -267,6 +277,11 @@ void ControlDeck::SaveSettings() {
             config->SetBool(NESTED("Gyro.Enabled", ""), profile->UseGyro);
             config->SetInt(NESTED("Notches.ProximityThreshold", ""), profile->NotchProximityThreshold);
             config->SetBool(NESTED("UseStickDeadzoneForButtons", ""), profile->UseStickDeadzoneForButtons);
+            config->SetBool(NESTED("Ess.Enabled", ""), profile->UseEssAdapter);
+            config->SetInt(NESTED("Analog.Threshold", ""), profile->InputEssMin);
+            config->SetInt(NESTED("Analog.Max", ""), profile->InputEssMax);
+            config->SetInt(NESTED("Ess.Min", ""), profile->EssMin);
+            config->SetInt(NESTED("Ess.Max", ""), profile->EssMax);
 
             // Clear all sections with a one controller to many relationship.
             const static std::vector<std::string> sClearSections = { "Mappings", "AxisDeadzones", "AxisMinimumPress",

--- a/src/controller/ControlDeck.cpp
+++ b/src/controller/ControlDeck.cpp
@@ -2,6 +2,7 @@
 
 #include "Context.h"
 #include "Controller.h"
+#include "../config//Config.h"
 #include "DummyController.h"
 #include <Utils/StringHelper.h>
 #include "public/bridge/consolevariablebridge.h"
@@ -185,11 +186,19 @@ void ControlDeck::LoadSettings() {
                     profile->RumbleStrength = config->GetFloat(NESTED("Rumble.Strength", ""));
                     profile->UseGyro = config->GetBool(NESTED("Gyro.Enabled", ""));
                     profile->NotchProximityThreshold = config->GetInt(NESTED("Notches.ProximityThreshold", ""));
-                    profile->UseEssAdapter = config->GetBool(NESTED("Ess.Enabled", ""));
-                    profile->InputEssMin = config->GetInt(NESTED("Analog.Threshold", ""));
-                    profile->InputEssMax = config->GetInt(NESTED("Analog.Max", ""));
-                    profile->EssMin = config->GetInt(NESTED("Ess.Min", ""));
-                    profile->EssMax = config->GetInt(NESTED("Ess.Max", ""));
+                    profile->UseJoystickInterpolation =
+                        config->GetBool(NESTED("JoystickInterpolation.UseJoystickInterpolation"));
+                    profile->NbJoystickInterpolaion = config->GetInt(NESTED("JoystickInterpolation.NbOfZones"));
+                    
+                    for (int i = 0; i < profile->NbJoystickInterpolaion * 2; ++i) {
+                        profile->JoystickInterpolation_Analog.push_back(
+                            config->GetInt(NESTED("JoystickInterpolation.Analog%d", i)));
+                    }
+
+                    for (int i = 0; i < profile->NbJoystickInterpolaion * 2; ++i) {
+                        profile->JoystickInterpolation_Result.push_back(
+                            config->GetInt(NESTED("JoystickInterpolation.Result%d", i)));
+                    }
 
                     for (auto const& val : rawProfile["AxisDeadzones"].items()) {
                         profile->AxisDeadzones[std::stoi(val.key())] = val.value();
@@ -220,6 +229,19 @@ void ControlDeck::LoadSettings() {
                     profile->InputEssMax = config->GetInt(NESTED("Analog.Max", ""));
                     profile->EssMin = config->GetInt(NESTED("Ess.Min", ""));
                     profile->EssMax = config->GetInt(NESTED("Ess.Max", ""));
+                    profile->UseJoystickInterpolation =
+                        config->GetBool(NESTED("JoystickInterpolation.UseJoystickInterpolation"));
+                    profile->NbJoystickInterpolaion = config->GetInt(NESTED("JoystickInterpolation.NbOfZones"));
+
+                    for (int i = 0; i < profile->NbJoystickInterpolaion * 2; ++i) {
+                        int value = config->GetInt(NESTED("JoystickInterpolation.Analog%d", i));
+                        profile->JoystickInterpolation_Analog.push_back(value);
+                    }
+
+                    for (int i = 0; i < profile->NbJoystickInterpolaion * 2; ++i) {
+                        profile->JoystickInterpolation_Result.push_back(
+                            config->GetInt(NESTED("JoystickInterpolation.Result%d", i)));
+                    }
 
                     for (auto const& val : rawProfile["AxisDeadzones"].items()) {
                         profile->AxisDeadzones[std::stoi(val.key())] = val.value();
@@ -282,6 +304,11 @@ void ControlDeck::SaveSettings() {
             config->SetInt(NESTED("Analog.Max", ""), profile->InputEssMax);
             config->SetInt(NESTED("Ess.Min", ""), profile->EssMin);
             config->SetInt(NESTED("Ess.Max", ""), profile->EssMax);
+            config->SetBool(NESTED("JoystickInterpolation.UseJoystickInterpolation", ""),
+                            profile->UseJoystickInterpolation);
+
+            auto nbInterpolationZones = profile->JoystickInterpolation_Analog.size() / 2;
+            config->SetInt(NESTED("JoystickInterpolation.NbOfZones", ""), nbInterpolationZones);
 
             // Clear all sections with a one controller to many relationship.
             const static std::vector<std::string> sClearSections = { "Mappings", "AxisDeadzones", "AxisMinimumPress",
@@ -293,6 +320,18 @@ void ControlDeck::SaveSettings() {
                     }
                 }
             }
+
+            for (int i = 0; i < nbInterpolationZones * 2; ++i) {
+                config->SetInt(NESTED("JoystickInterpolation.Analog%d", i), profile->JoystickInterpolation_Analog[i]);
+            }
+
+            for (int i = 0; i < nbInterpolationZones * 2; ++i) {
+                config->SetInt(NESTED("JoystickInterpolation.Result%d", i), profile->JoystickInterpolation_Result[i]);
+            }
+
+            /*for (int i = 0; i < nbInterpolationZones; ++i) {
+                config->SetInt(NESTED("JoystickInterpolation.Type.%d", i), profile->JoystickInterpolation_Type[i]);
+            }*/
 
             for (auto const& [key, val] : profile->Mappings) {
                 config->SetInt(NESTED("Mappings.%d", key), val);

--- a/src/controller/ControlDeck.cpp
+++ b/src/controller/ControlDeck.cpp
@@ -224,11 +224,6 @@ void ControlDeck::LoadSettings() {
                     profile->UseGyro = config->GetBool(NESTED("Gyro.Enabled", ""));
                     profile->NotchProximityThreshold = config->GetInt(NESTED("Notches.ProximityThreshold", ""));
                     profile->UseStickDeadzoneForButtons = config->GetBool(NESTED("UseStickDeadzoneForButtons", ""));
-                    profile->UseEssAdapter = config->GetBool(NESTED("Ess.Enabled", ""));
-                    profile->InputEssMin = config->GetInt(NESTED("Analog.Threshold", ""));
-                    profile->InputEssMax = config->GetInt(NESTED("Analog.Max", ""));
-                    profile->EssMin = config->GetInt(NESTED("Ess.Min", ""));
-                    profile->EssMax = config->GetInt(NESTED("Ess.Max", ""));
                     profile->UseJoystickInterpolation =
                         config->GetBool(NESTED("JoystickInterpolation.UseJoystickInterpolation"));
                     profile->NbJoystickInterpolaion = config->GetInt(NESTED("JoystickInterpolation.NbOfZones"));
@@ -299,11 +294,6 @@ void ControlDeck::SaveSettings() {
             config->SetBool(NESTED("Gyro.Enabled", ""), profile->UseGyro);
             config->SetInt(NESTED("Notches.ProximityThreshold", ""), profile->NotchProximityThreshold);
             config->SetBool(NESTED("UseStickDeadzoneForButtons", ""), profile->UseStickDeadzoneForButtons);
-            config->SetBool(NESTED("Ess.Enabled", ""), profile->UseEssAdapter);
-            config->SetInt(NESTED("Analog.Threshold", ""), profile->InputEssMin);
-            config->SetInt(NESTED("Analog.Max", ""), profile->InputEssMax);
-            config->SetInt(NESTED("Ess.Min", ""), profile->EssMin);
-            config->SetInt(NESTED("Ess.Max", ""), profile->EssMax);
             config->SetBool(NESTED("JoystickInterpolation.UseJoystickInterpolation", ""),
                             profile->UseJoystickInterpolation);
 

--- a/src/controller/ControlDeck.cpp
+++ b/src/controller/ControlDeck.cpp
@@ -187,8 +187,8 @@ void ControlDeck::LoadSettings() {
                     profile->UseGyro = config->GetBool(NESTED("Gyro.Enabled", ""));
                     profile->NotchProximityThreshold = config->GetInt(NESTED("Notches.ProximityThreshold", ""));
                     profile->UseJoystickInterpolation =
-                        config->GetBool(NESTED("JoystickInterpolation.UseJoystickInterpolation"));
-                    profile->NbJoystickInterpolaion = config->GetInt(NESTED("JoystickInterpolation.NbOfZones"));
+                        config->GetBool(NESTED("JoystickInterpolation.UseJoystickInterpolation", ""));
+                    profile->NbJoystickInterpolaion = config->GetInt(NESTED("JoystickInterpolation.NbOfZones", ""));
                     
                     for (int i = 0; i < profile->NbJoystickInterpolaion * 2; ++i) {
                         profile->JoystickInterpolation_Analog.push_back(
@@ -225,8 +225,8 @@ void ControlDeck::LoadSettings() {
                     profile->NotchProximityThreshold = config->GetInt(NESTED("Notches.ProximityThreshold", ""));
                     profile->UseStickDeadzoneForButtons = config->GetBool(NESTED("UseStickDeadzoneForButtons", ""));
                     profile->UseJoystickInterpolation =
-                        config->GetBool(NESTED("JoystickInterpolation.UseJoystickInterpolation"));
-                    profile->NbJoystickInterpolaion = config->GetInt(NESTED("JoystickInterpolation.NbOfZones"));
+                        config->GetBool(NESTED("JoystickInterpolation.UseJoystickInterpolation", ""));
+                    profile->NbJoystickInterpolaion = config->GetInt(NESTED("JoystickInterpolation.NbOfZones", ""));
 
                     for (int i = 0; i < profile->NbJoystickInterpolaion * 2; ++i) {
                         int value = config->GetInt(NESTED("JoystickInterpolation.Analog%d", i));

--- a/src/controller/Controller.cpp
+++ b/src/controller/Controller.cpp
@@ -112,12 +112,12 @@ void Controller::ProcessStick(int8_t& x, int8_t& y, float deadzoneX, float deadz
         len = (len - deadzoneX) * MAX_AXIS_RANGE / (MAX_AXIS_RANGE - deadzoneX) / len;
     }
 
+    ux *= len;
+    uy *= len;
+
     if (useEssAdapter) {
         ModifyForEss(ux, uy, inputEssMin, inputEssMax, essMin, essMax);
     }
-
-    ux *= len;
-    uy *= len;
 
     // bound diagonals to an octagonal range {-69 ... +69}
     if (ux != 0.0 && uy != 0.0) {
@@ -249,9 +249,10 @@ void Controller::ModifyForEss(double &ux, double &uy, int32_t inputEssMin, int32
     double ratio = (distanceFromCenter / (double)inputEssMax);
     double essDistance = std::lerp((double)essMin, (double)essMax, ratio);
     double angle = 0.0;
-    if (ux < MINIMUM_RADIUS_TO_MAP_NOTCH) {
+    double epsilon = std::numeric_limits<double>::epsilon();
+    if (ux < epsilon) {
         angle = 90.0 * (M_PI / 180) ;
-    } else if (uy < MINIMUM_RADIUS_TO_MAP_NOTCH) {
+    } else if (uy < epsilon) {
         angle = 0.0 * (M_PI / 180);
     } else {
         angle = std::atan(uy / ux);

--- a/src/controller/Controller.cpp
+++ b/src/controller/Controller.cpp
@@ -101,7 +101,7 @@ void Controller::ProcessStick(int8_t& x, int8_t& y, float deadzoneX, float deadz
         SPDLOG_TRACE("Invalid Deadzone configured. Up/Down was {} and Left/Right is {}", deadzoneY, deadzoneX);
     }
 
-    if (useJoystickInterpolation) {
+    if (useJoystickInterpolation && analogs.size() > 0) {
         ApplyJoystickInterpolation(ux, uy, analogs, results);
     } else {
         // create scaled circular dead-zone

--- a/src/controller/Controller.cpp
+++ b/src/controller/Controller.cpp
@@ -12,6 +12,7 @@
 #define M_TAU 6.2831853071795864769252867665590057 // 2 * pi
 #define M_PI 3.14159265358979323846                // pi
 #define MINIMUM_RADIUS_TO_MAP_NOTCH 0.9
+#define DOUBLE_EPSILON 2.2204460492503131e-016     // smallest such that 1.0+DBL_EPSILON != 1.0
 
 namespace LUS {
 
@@ -303,9 +304,9 @@ void Controller::ApplyJoystickInterpolation(double& ux, double& uy, std::vector<
 
     double angle = 0.0;
     // get angle in rads
-    if (ux < DBL_EPSILON) {
+    if (ux < DOUBLE_EPSILON) {
         angle = 90.0 * (M_PI / 180);
-    } else if (uy < DBL_EPSILON) {
+    } else if (uy < DOUBLE_EPSILON) {
         angle = 0.0 * (M_PI / 180);
     } else {
         angle = std::atan(uy / ux);

--- a/src/controller/Controller.h
+++ b/src/controller/Controller.h
@@ -18,8 +18,26 @@ enum GyroData { DRIFT_X, DRIFT_Y, GYRO_SENSITIVITY };
 enum Stick { LEFT, RIGHT };
 enum Axis { X, Y };
 enum DeviceProfileVersion { DEVICE_PROFILE_VERSION_0 = 0, DEVICE_PROFILE_VERSION_1 = 1, DEVICE_PROFILE_VERSION_2 = 2 };
+enum InterpolationType { DEADZONE = 0, LINEAR = 1 };
 
 #define DEVICE_PROFILE_CURRENT_VERSION DEVICE_PROFILE_VERSION_2
+
+struct JoystickInterpolationData {
+    double AnalogMin;
+    double AnalogMax;
+    double ResultMin;
+    double ResultMax;
+    InterpolationType Interpolation;
+
+    JoystickInterpolationData(double analogMin, double analogMax, double resultMin, double resultMax,
+                              InterpolationType interpolation) {
+        AnalogMin = analogMin;
+        AnalogMax = analogMax;
+        ResultMin = resultMin;
+        ResultMax = resultMax;
+        Interpolation = interpolation;
+    }
+};
 
 struct DeviceProfile {
     int32_t Version = 0;
@@ -28,11 +46,11 @@ struct DeviceProfile {
     bool UseStickDeadzoneForButtons = false;
     float RumbleStrength = 1.0f;
     int32_t NotchProximityThreshold = 0;
-    bool UseEssAdapter = 0;
-    int32_t InputEssMin = 0;
-    int32_t InputEssMax = 0;
-    int32_t EssMin = 0;
-    int32_t EssMax = 0;
+    bool UseJoystickInterpolation = false;
+    int NbJoystickInterpolaion = 0;
+    std::vector<int> JoystickInterpolation_Analog;
+    std::vector<int> JoystickInterpolation_Result;
+    std::vector<InterpolationType> JoystickInterpolation_Type;
     std::unordered_map<int32_t, float> AxisDeadzones;
     std::unordered_map<int32_t, float> AxisMinimumPress;
     std::unordered_map<int32_t, float> GyroData;
@@ -64,8 +82,6 @@ class Controller {
     int8_t& GetLeftStickY(int32_t portIndex);
     int8_t& GetRightStickX(int32_t portIndex);
     int8_t& GetRightStickY(int32_t portIndex);
-    void ModifyForEss(double &ux, double &uy, int32_t analogThreshold, int32_t analogMax, int32_t essMin,
-                         int32_t essMax);
     int32_t& GetPressedButtons(int32_t portIndex);
     float& GetGyroX(int32_t portIndex);
     float& GetGyroY(int32_t portIndex);
@@ -81,7 +97,8 @@ class Controller {
     std::string mControllerName = "Unknown";
 
     int8_t ReadStick(int32_t portIndex, Stick stick, Axis axis);
-    void ProcessStick(int8_t& x, int8_t& y, float deadzoneX, float deadzoneY, int32_t notchProxmityThreshold, bool useEssAdapter, int32_t analogMin, int32_t analogMax, int32_t essMin, int32_t essMax);
+    void ProcessStick(int8_t& x, int8_t& y, float deadzoneX, float deadzoneY, int32_t notchProxmityThreshold,
+                      bool useJoystickInterpolation, std::vector<int> analogs, std::vector<int> results);
     double GetClosestNotch(double angle, double approximationThreshold);
 
   private:
@@ -98,5 +115,10 @@ class Controller {
     std::unordered_map<int32_t, std::shared_ptr<DeviceProfile>> mProfiles;
     std::unordered_map<int32_t, std::shared_ptr<Buttons>> mButtonData = {};
     std::deque<OSContPad> mPadBuffer;
+
+    void ApplyJoystickInterpolation(double& ux, double& uy, std::vector<int> analogs, std::vector<int> results);
+    double CalculateInerpolationValue(double v, int analogMin, int analogMax, int resultMin, int resultMax,
+                                      InterpolationType interpolationType);
+    double CalculateLinearInterpolation(double v, int inputMin, int inputMax, int resultMin, int resultMax);
 };
 } // namespace LUS

--- a/src/controller/Controller.h
+++ b/src/controller/Controller.h
@@ -28,6 +28,11 @@ struct DeviceProfile {
     bool UseStickDeadzoneForButtons = false;
     float RumbleStrength = 1.0f;
     int32_t NotchProximityThreshold = 0;
+    bool UseEssAdapter = 0;
+    int32_t InputEssMin = 0;
+    int32_t InputEssMax = 0;
+    int32_t EssMin = 0;
+    int32_t EssMax = 0;
     std::unordered_map<int32_t, float> AxisDeadzones;
     std::unordered_map<int32_t, float> AxisMinimumPress;
     std::unordered_map<int32_t, float> GyroData;
@@ -59,6 +64,8 @@ class Controller {
     int8_t& GetLeftStickY(int32_t portIndex);
     int8_t& GetRightStickX(int32_t portIndex);
     int8_t& GetRightStickY(int32_t portIndex);
+    void ModifyForEss(double &ux, double &uy, int32_t analogThreshold, int32_t analogMax, int32_t essMin,
+                         int32_t essMax);
     int32_t& GetPressedButtons(int32_t portIndex);
     float& GetGyroX(int32_t portIndex);
     float& GetGyroY(int32_t portIndex);
@@ -74,7 +81,7 @@ class Controller {
     std::string mControllerName = "Unknown";
 
     int8_t ReadStick(int32_t portIndex, Stick stick, Axis axis);
-    void ProcessStick(int8_t& x, int8_t& y, float deadzoneX, float deadzoneY, int32_t notchProxmityThreshold);
+    void ProcessStick(int8_t& x, int8_t& y, float deadzoneX, float deadzoneY, int32_t notchProxmityThreshold, bool useEssAdapter, int32_t analogMin, int32_t analogMax, int32_t essMin, int32_t essMax);
     double GetClosestNotch(double angle, double approximationThreshold);
 
   private:

--- a/src/window/gui/InputEditorWindow.cpp
+++ b/src/window/gui/InputEditorWindow.cpp
@@ -242,7 +242,7 @@ void InputEditorWindow::DrawControllerSchema() {
         ImGui::PopItemWidth();
         ImGui::EndChild();
 
-        ImGui::BeginChild("##MSInput0", ImVec2(90, 50), false);
+        ImGui::BeginChild("##MSInput0", ImVec2(150, 50), false);
         ImGui::Text("Ess Adapter Enabled");
         ImGui::PushItemWidth(80);
         if (ImGui::Checkbox("##MDZone0", &profile->UseEssAdapter)) {
@@ -251,8 +251,8 @@ void InputEditorWindow::DrawControllerSchema() {
         ImGui::PopItemWidth();
         ImGui::EndChild();
 
-        ImGui::BeginChild("##MSInput1", ImVec2(90, 50), false);
-        ImGui::Text("Analog Threshold");
+        ImGui::BeginChild("##MSInput1", ImVec2(150, 50), false);
+        ImGui::Text("Analog Input Min");
         ImGui::PushItemWidth(80);
         if (ImGui::InputInt("##MDZone1", &profile->InputEssMin, 1.0f, 0.0f)) {
             Context::GetInstance()->GetControlDeck()->SaveSettings();
@@ -260,8 +260,8 @@ void InputEditorWindow::DrawControllerSchema() {
         ImGui::PopItemWidth();
         ImGui::EndChild();
 
-        ImGui::BeginChild("##MSInput2", ImVec2(90, 50), false);
-        ImGui::Text("Analog Max");
+        ImGui::BeginChild("##MSInput2", ImVec2(150, 50), false);
+        ImGui::Text("Analog Input Max");
         ImGui::PushItemWidth(80);
         if (ImGui::InputInt("##MDZone2", &profile->InputEssMax, 1.0f, 0.0f)) {
             Context::GetInstance()->GetControlDeck()->SaveSettings();

--- a/src/window/gui/InputEditorWindow.cpp
+++ b/src/window/gui/InputEditorWindow.cpp
@@ -489,19 +489,19 @@ void InputEditorWindow::DrawControllerSchema() {
 
 void InputEditorWindow::DrawJoystickInterpolationZone(int& analogMin, int& analogMax, int& resultMin, int& resultMax,
                                                       int index) {
-    BeginGroupPanel(std::format("Joystick zone {}", index).c_str(), ImVec2(500, 200));
-    if (ImGui::InputInt(std::format("Analog Min {}", index).c_str(), &analogMin)) {
+    BeginGroupPanel(StringHelper::Sprintf("Joystick zone %d", index).c_str(), ImVec2(500, 200));
+    if (ImGui::InputInt(StringHelper::Sprintf("Analog Min %d", index).c_str(), &analogMin)) {
         Context::GetInstance()->GetControlDeck()->SaveSettings();
     }
     ImGui::SameLine();
-    if (ImGui::InputInt(std::format("Result Min {}", index).c_str(), &resultMin)) { 
+    if (ImGui::InputInt(StringHelper::Sprintf("Result Min %d", index).c_str(), &resultMin)) { 
         Context::GetInstance()->GetControlDeck()->SaveSettings();
     }
-    if (ImGui::InputInt(std::format("Analog Max {}", index).c_str(), &analogMax)) {
+    if (ImGui::InputInt(StringHelper::Sprintf("Analog Max %d", index).c_str(), &analogMax)) {
         Context::GetInstance()->GetControlDeck()->SaveSettings();
     }
     ImGui::SameLine();
-    if (ImGui::InputInt(std::format("Result Max {}", index).c_str(), &resultMax)) {
+    if (ImGui::InputInt(StringHelper::Sprintf("Result Max %d", index).c_str(), &resultMax)) {
         Context::GetInstance()->GetControlDeck()->SaveSettings();    
     }
     EndGroupPanel(2.0f);

--- a/src/window/gui/InputEditorWindow.cpp
+++ b/src/window/gui/InputEditorWindow.cpp
@@ -241,6 +241,51 @@ void InputEditorWindow::DrawControllerSchema() {
         }
         ImGui::PopItemWidth();
         ImGui::EndChild();
+
+        ImGui::BeginChild("##MSInput0", ImVec2(90, 50), false);
+        ImGui::Text("Ess Adapter Enabled");
+        ImGui::PushItemWidth(80);
+        if (ImGui::Checkbox("##MDZone0", &profile->UseEssAdapter)) {
+            Context::GetInstance()->GetControlDeck()->SaveSettings();
+        }
+        ImGui::PopItemWidth();
+        ImGui::EndChild();
+
+        ImGui::BeginChild("##MSInput1", ImVec2(90, 50), false);
+        ImGui::Text("Analog Threshold");
+        ImGui::PushItemWidth(80);
+        if (ImGui::InputInt("##MDZone1", &profile->InputEssMin, 1.0f, 0.0f)) {
+            Context::GetInstance()->GetControlDeck()->SaveSettings();
+        }
+        ImGui::PopItemWidth();
+        ImGui::EndChild();
+
+        ImGui::BeginChild("##MSInput2", ImVec2(90, 50), false);
+        ImGui::Text("Analog Max");
+        ImGui::PushItemWidth(80);
+        if (ImGui::InputInt("##MDZone2", &profile->InputEssMax, 1.0f, 0.0f)) {
+            Context::GetInstance()->GetControlDeck()->SaveSettings();
+        }
+        ImGui::PopItemWidth();
+        ImGui::EndChild();
+
+        ImGui::BeginChild("##MSInput3", ImVec2(90, 50), false);
+        ImGui::Text("ESS Min");
+        ImGui::PushItemWidth(80);
+        if (ImGui::InputInt("##MDZone3", &profile->EssMin, 1.0f, 0.0f)) {
+            Context::GetInstance()->GetControlDeck()->SaveSettings();
+        }
+        ImGui::PopItemWidth();
+        ImGui::EndChild();
+
+        ImGui::BeginChild("##MSInput4", ImVec2(90, 50), false);
+        ImGui::Text("ESS Max");
+        ImGui::PushItemWidth(80);
+        if (ImGui::InputInt("##MDZone4", &profile->EssMax, 1.0f, 0.0f)) {
+            Context::GetInstance()->GetControlDeck()->SaveSettings();
+        }
+        ImGui::PopItemWidth();
+        ImGui::EndChild();
     } else {
         ImGui::Dummy(ImVec2(0, 6));
     }

--- a/src/window/gui/InputEditorWindow.cpp
+++ b/src/window/gui/InputEditorWindow.cpp
@@ -213,79 +213,37 @@ void InputEditorWindow::DrawControllerSchema() {
         DrawVirtualStick("##MainVirtualStick",
                          ImVec2(backend->GetLeftStickX(mCurrentPort), backend->GetLeftStickY(mCurrentPort)),
                          profile->AxisDeadzones[0]);
-        ImGui::SameLine();
 
-        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 5);
+        if (!profile->UseJoystickInterpolation) {
+            ImGui::SameLine();
 
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 5);
 #ifdef __WIIU__
-        ImGui::BeginChild("##MSInput", ImVec2(90 * 2, 50 * 2), false);
+            ImGui::BeginChild("##MSInput", ImVec2(90 * 2, 50 * 2), false);
 #else
-        ImGui::BeginChild("##MSInput", ImVec2(90, 50), false);
+            ImGui::BeginChild("##MSInput", ImVec2(90, 50), false);
 #endif
-        ImGui::Text("Deadzone");
+            ImGui::Text("Deadzone");
 #ifdef __WIIU__
-        ImGui::PushItemWidth(80 * 2);
+            ImGui::PushItemWidth(80 * 2);
 #else
-        ImGui::PushItemWidth(80);
+            ImGui::PushItemWidth(80);
 #endif
-        // The window has deadzone per stick, so we need to
-        // set the deadzone for both left stick axes here
-        // SDL_CONTROLLER_AXIS_LEFTX: 0
-        // SDL_CONTROLLER_AXIS_LEFTY: 1
-        if (ImGui::InputFloat("##MDZone", &profile->AxisDeadzones[0], 1.0f, 0.0f, "%.0f")) {
-            if (profile->AxisDeadzones[0] < 0) {
-                profile->AxisDeadzones[0] = 0;
+            // The window has deadzone per stick, so we need to
+            // set the deadzone for both left stick axes here
+            // SDL_CONTROLLER_AXIS_LEFTX: 0
+            // SDL_CONTROLLER_AXIS_LEFTY: 1
+            if (ImGui::InputFloat("##MDZone", &profile->AxisDeadzones[0], 1.0f, 0.0f, "%.0f")) {
+                if (profile->AxisDeadzones[0] < 0) {
+                    profile->AxisDeadzones[0] = 0;
+                }
+                profile->AxisDeadzones[1] = profile->AxisDeadzones[0];
+                Context::GetInstance()->GetControlDeck()->SaveSettings();
             }
-            profile->AxisDeadzones[1] = profile->AxisDeadzones[0];
-            Context::GetInstance()->GetControlDeck()->SaveSettings();
+            ImGui::PopItemWidth();
+            ImGui::EndChild();
         }
-        ImGui::PopItemWidth();
-        ImGui::EndChild();
 
-        ImGui::BeginChild("##MSInput0", ImVec2(150, 50), false);
-        ImGui::Text("Ess Adapter Enabled");
-        ImGui::PushItemWidth(80);
-        if (ImGui::Checkbox("##MDZone0", &profile->UseEssAdapter)) {
-            Context::GetInstance()->GetControlDeck()->SaveSettings();
-        }
-        ImGui::PopItemWidth();
-        ImGui::EndChild();
-
-        ImGui::BeginChild("##MSInput1", ImVec2(150, 50), false);
-        ImGui::Text("Analog Input Min");
-        ImGui::PushItemWidth(80);
-        if (ImGui::InputInt("##MDZone1", &profile->InputEssMin, 1.0f, 0.0f)) {
-            Context::GetInstance()->GetControlDeck()->SaveSettings();
-        }
-        ImGui::PopItemWidth();
-        ImGui::EndChild();
-
-        ImGui::BeginChild("##MSInput2", ImVec2(150, 50), false);
-        ImGui::Text("Analog Input Max");
-        ImGui::PushItemWidth(80);
-        if (ImGui::InputInt("##MDZone2", &profile->InputEssMax, 1.0f, 0.0f)) {
-            Context::GetInstance()->GetControlDeck()->SaveSettings();
-        }
-        ImGui::PopItemWidth();
-        ImGui::EndChild();
-
-        ImGui::BeginChild("##MSInput3", ImVec2(90, 50), false);
-        ImGui::Text("ESS Min");
-        ImGui::PushItemWidth(80);
-        if (ImGui::InputInt("##MDZone3", &profile->EssMin, 1.0f, 0.0f)) {
-            Context::GetInstance()->GetControlDeck()->SaveSettings();
-        }
-        ImGui::PopItemWidth();
-        ImGui::EndChild();
-
-        ImGui::BeginChild("##MSInput4", ImVec2(90, 50), false);
-        ImGui::Text("ESS Max");
-        ImGui::PushItemWidth(80);
-        if (ImGui::InputInt("##MDZone4", &profile->EssMax, 1.0f, 0.0f)) {
-            Context::GetInstance()->GetControlDeck()->SaveSettings();
-        }
-        ImGui::PopItemWidth();
-        ImGui::EndChild();
     } else {
         ImGui::Dummy(ImVec2(0, 6));
     }
@@ -482,6 +440,71 @@ void InputEditorWindow::DrawControllerSchema() {
 
     ImGui::Dummy(ImVec2(0, 5));
     EndGroupPanel(isKeyboard ? 0.0f : 2.0f);
+
+    // Draw joystick interpolation
+    if (!isKeyboard) {
+        BeginGroupPanel("Joystick Interpolation", ImVec2(500, 1000));
+        cursorX = ImGui::GetCursorPosX() + 5;
+        ImGui::SetCursorPosX(cursorX);
+        if (ImGui::Checkbox("Use Joystick Interpolation", &profile->UseJoystickInterpolation)) {
+            Context::GetInstance()->GetControlDeck()->SaveSettings();
+        }
+        
+        if (profile->UseJoystickInterpolation) {
+            if (ImGui::Button("Add Interpolation Zone", ImVec2(200, 25))) {
+                if (profile->JoystickInterpolation_Analog.size() == 0) {
+                    profile->JoystickInterpolation_Analog.push_back(0);
+                    profile->JoystickInterpolation_Analog.push_back(85);
+                } else {
+                    profile->JoystickInterpolation_Analog.push_back(profile->JoystickInterpolation_Analog.back());
+                    profile->JoystickInterpolation_Analog.push_back(profile->JoystickInterpolation_Analog.back());
+                }
+
+                if (profile->JoystickInterpolation_Result.size() == 0) {
+                    profile->JoystickInterpolation_Result.push_back(0);
+                    profile->JoystickInterpolation_Result.push_back(85);
+                } else {
+                    profile->JoystickInterpolation_Result.push_back(profile->JoystickInterpolation_Result.back());
+                    profile->JoystickInterpolation_Result.push_back(profile->JoystickInterpolation_Result.back());
+                }
+
+                Context::GetInstance()->GetControlDeck()->SaveSettings();
+            }
+
+            auto analogSize = profile->JoystickInterpolation_Analog.size();
+            if (analogSize > 0)
+            {
+                for (int i = 0; i < analogSize - 1; i += 2) {
+                    DrawJoystickInterpolationZone(
+                        profile->JoystickInterpolation_Analog[i], profile->JoystickInterpolation_Analog[(i + 1)],
+                        profile->JoystickInterpolation_Result[i], profile->JoystickInterpolation_Result[(i + 1)], (i / 2) + 1);
+                }
+            }
+        }
+
+        ImGui::Dummy(ImVec2(0, 5));
+        EndGroupPanel(2.0f);
+    }
+}
+
+void InputEditorWindow::DrawJoystickInterpolationZone(int& analogMin, int& analogMax, int& resultMin, int& resultMax,
+                                                      int index) {
+    BeginGroupPanel(std::format("Joystick zone {}", index).c_str(), ImVec2(500, 200));
+    if (ImGui::InputInt(std::format("Analog Min {}", index).c_str(), &analogMin)) {
+        Context::GetInstance()->GetControlDeck()->SaveSettings();
+    }
+    ImGui::SameLine();
+    if (ImGui::InputInt(std::format("Result Min {}", index).c_str(), &resultMin)) { 
+        Context::GetInstance()->GetControlDeck()->SaveSettings();
+    }
+    if (ImGui::InputInt(std::format("Analog Max {}", index).c_str(), &analogMax)) {
+        Context::GetInstance()->GetControlDeck()->SaveSettings();
+    }
+    ImGui::SameLine();
+    if (ImGui::InputInt(std::format("Result Max {}", index).c_str(), &resultMax)) {
+        Context::GetInstance()->GetControlDeck()->SaveSettings();    
+    }
+    EndGroupPanel(2.0f);
 }
 
 void InputEditorWindow::UpdateElement() {
@@ -503,7 +526,7 @@ void InputEditorWindow::DrawElement() {
     ImVec2 maxSize = ImVec2(1200 * 2, 330 * 2);
 #else
     ImVec2 minSize = ImVec2(641, 250);
-    ImVec2 maxSize = ImVec2(1200, 330);
+    ImVec2 maxSize = ImVec2(1200, 600);
 #endif
 
     ImGui::SetNextWindowSizeConstraints(minSize, maxSize);

--- a/src/window/gui/InputEditorWindow.h
+++ b/src/window/gui/InputEditorWindow.h
@@ -2,6 +2,7 @@
 
 #include "stdint.h"
 #include "window/gui/GuiWindow.h"
+#include "../../controller/Controller.h"
 #include <ImGui/imgui.h>
 
 namespace LUS {
@@ -15,6 +16,7 @@ class InputEditorWindow : public GuiWindow {
     void DrawControllerSelect(int32_t currentPort);
     void DrawVirtualStick(const char* label, ImVec2 stick, float deadzone = 0);
     void DrawControllerSchema();
+    void DrawJoystickInterpolationZone(int& analogMin, int& analogMax, int& resultMin, int& resultMax, int index);
 
   protected:
     void InitElement() override;


### PR DESCRIPTION
## What
Adding an ESS adapter to facilitate certain movements, such as hessing in OOT

## Why
ESS position can be difficult to achieve on certain hardware. This ess adapter gives configurable leniency for ESS position.

## How
Take the direction the stick has been moved and evaluate it's position. If it falls within the threshold (`inputEssMin`, `inputEssMax`), we then adjust the length of the directional input along the same vector.

## Known Issues
- Screws up aiming in first person
- Makes walking difficult